### PR TITLE
Feature:  Use External Selenium Server

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,9 +2,13 @@ var Promise = require('es6-promise').Promise
 var webdriverio = require('webdriverio')
 var seleniumHelper = require('./helpers/selenium')
 
+function noOp () {}
+
 function validateState (state) {
   return state.browser
-    .then(function () { return state })
+    .then(function (err) {
+      return state
+    })
     .catch(function (err) {
       return teardown(state)
         .then(function () { throw err })
@@ -23,10 +27,22 @@ function makeHarnessState (client, child) {
 
 function setup (opts) {
   opts = opts || {}
+  var custom = opts.custom || {}
   var seleniumOpts = opts.selenium || {}
   var webdriverOpts = opts.webdriverio || {}
   var remote = webdriverOpts.remote || {}
   var init = webdriverOpts.init || {}
+
+  if (custom.remoteSelenium) {
+    return Promise.resolve(
+      validateState(
+      makeHarnessState(
+        makeClient(remote, init),
+        { kill: noOp }
+      )).then(function (state) {
+        return state
+      }))
+  }
 
   return seleniumHelper
     .setup(seleniumOpts)

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,18 +1,39 @@
 var Promise = require('es6-promise').Promise
 var webdriverio = require('webdriverio')
 var seleniumHelper = require('./helpers/selenium')
+var seleniumStub = { kill: function () {}}
 
-function noOp () {}
+function setup (opts) {
+  opts = formatOptions(opts)
+  var remoteSelenium = opts.custom.remoteSelenium
 
-function validateState (state) {
-  return state.browser
-    .then(function (err) {
-      return state
-    })
-    .catch(function (err) {
-      return teardown(state)
-        .then(function () { throw err })
-    })
+  if (remoteSelenium) { return build(opts.webdriverio, seleniumStub) }
+
+  return seleniumHelper
+    .setup(opts.selenium)
+    .then(function (child) { return build(opts.webdriverio, child) })
+}
+
+function teardown (state) {
+  return state.browser.end().then(function () {
+    return seleniumHelper.teardown(state.selenium)
+  })
+}
+
+function build(opts, child) {
+  var client = makeClient(opts.remote, opts.init)
+  var state = makeHarnessState(client, child)
+  return validateState(state)
+}
+
+function formatOptions (opts) {
+  opts = opts || {}
+  opts.custom = opts.custom || {}
+  opts.selenium = opts.selenium || {}
+  opts.webdriverio = opts.webdriverio || {}
+  opts.webdriverio.remote = opts.webdriverio.remote || {}
+  opts.webdriverio.init = opts.webdriverio.init || {}
+  return opts
 }
 
 function makeClient (remote, init) {
@@ -25,38 +46,13 @@ function makeHarnessState (client, child) {
   return { browser: client, selenium: child }
 }
 
-function setup (opts) {
-  opts = opts || {}
-  var custom = opts.custom || {}
-  var seleniumOpts = opts.selenium || {}
-  var webdriverOpts = opts.webdriverio || {}
-  var remote = webdriverOpts.remote || {}
-  var init = webdriverOpts.init || {}
-
-  if (custom.remoteSelenium) {
-    return Promise.resolve(
-      validateState(
-      makeHarnessState(
-        makeClient(remote, init),
-        { kill: noOp }
-      )).then(function (state) {
-        return state
-      }))
-  }
-
-  return seleniumHelper
-    .setup(seleniumOpts)
-    .then(function (child) {
-      var client = makeClient(remote, init)
-      var state = makeHarnessState(client, child)
-      return validateState(state)
+function validateState (state) {
+  return state.browser
+    .then(function () { return state })
+    .catch(function (err) {
+      return teardown(state)
+        .then(function () { Promise.reject(err) })
     })
-}
-
-function teardown (state) {
-  return state.browser.end().then(function () {
-    return seleniumHelper.teardown(state.selenium)
-  })
 }
 
 exports.setup = setup

--- a/test/integration.spec.js
+++ b/test/integration.spec.js
@@ -1,45 +1,71 @@
-var helper = require('./helpers')
-var expect = helper.expect
-var sinon = helper.sinon
+var assign = require('object-assign')
+var seleniumHelper = require('../lib/helpers/selenium')
+var pageVisitingBehavior = require('./shared/integration')
 var server = require('./helpers/server')
 var harness = require('../lib')
-
-var options = {
-  webdriverio: {
-    remote: {
-      desiredCapabilities: { browserName: 'phantomjs' }
-    }
-  }
-}
+var isCI = !!process.env.CI
 
 describe('WebdriverIO Selenium Harness integration', function () {
   before(function (done) {
-    var self = this
-    this.harnessState = harness.setup(options)
-    return this.harnessState.then(function (state) {
-      self.browser = state.browser
-      self.selenium = state.selenium
-      server.listen(9000, done)
-    })
+    var options = this.options = {
+      webdriverio: {
+        remote: { desiredCapabilities: { browserName: 'phantomjs' } }
+      }
+    }
+    server.listen(9000, done)
   })
 
-  after(function () {
-    return this.harnessState
-      .then(harness.teardown)
-      .then(function () { server.close() })
-  })
+  after(function () { server.close() })
 
-  describe('Feature: Test Page', function () {
-    context('When I visit the Test Page', function () {
-      it('contains proper title', function () {
-        var client = this.browser
-        return client
-          .url('http://localhost:9000')
-          .getTitle()
-          .then(function (title) {
-            expect(title).to.equal('Test Page')
-          })
+  describe('With local selenium', function () {
+    before(function () {
+      var self = this
+      var options = self.options = assign({}, this.options, {
+        custom: { remoteSelenium: isCI }
+      })
+      var harnessState = self.harnessState = harness.setup(options)
+      return harnessState.then(function (state) {
+        self.browser = state.browser
+        self.selenium = state.selenium
       })
     })
+
+    after(function () {
+      return this.harnessState.then(harness.teardown)
+    })
+
+    pageVisitingBehavior()
+  })
+
+  describe('With remote selenium', function () {
+    function getSeleniumPromise (isCI) {
+      if (isCI) {
+        return Promise.resolve({ kill: function () {} })
+      }
+      return seleniumHelper.setup({})
+    }
+
+    before(function () {
+      var self = this
+      var options = self.options = assign({}, this.options, {
+        custom: { remoteSelenium: true }
+      })
+
+      return getSeleniumPromise(isCI).then(function (child) {
+        self.selenium = child
+        return harness.setup(options).then(function (state) {
+          self.browser = state.browser
+        })
+      })
+    })
+
+    after(function () {
+      var self = this
+      return self.browser.end().then(function () {
+        return seleniumHelper.teardown(self.selenium)
+      })
+    })
+
+    pageVisitingBehavior()
   })
 })

--- a/test/shared/integration.js
+++ b/test/shared/integration.js
@@ -1,0 +1,18 @@
+var helper = require('../helpers')
+var expect = helper.expect
+
+module.exports = function () {
+  describe('Feature: Test Page', function () {
+    context('When I visit the Test Page', function () {
+      it('contains proper title', function () {
+        var client = this.browser
+        return client
+          .url('http://localhost:9000')
+          .getTitle()
+          .then(function (title) {
+            expect(title).to.equal('Test Page')
+          })
+      })
+    })
+  })
+}

--- a/test/shared/webdriverio.js
+++ b/test/shared/webdriverio.js
@@ -1,0 +1,101 @@
+var webdriverio = require('webdriverio')
+var assign = require('object-assign')
+var helpers = require('../helpers')
+var expect = helpers.expect
+
+module.exports = function (state) {
+  var lib = state.lib
+  var seleniumHelper = state.seleniumHelper
+  var childProcess = state.childProcess
+
+  context('and WebdriverIO fails', function () {
+    beforeEach(function () {
+      this.options = this.options || {}
+      this.error = { error: true }
+      this.client = Promise.reject(this.error)
+      this.initStub.returns(this.client)
+      this.client.end = this.sandbox.stub().returns(Promise.resolve())
+    })
+
+    it('closes the browser client', function () {
+      var client = this.client
+      var options = this.options
+      return lib.setup(options).catch(function () {
+        expect(client.end).to.have.been.called
+      })
+    })
+
+    it('propagates errors', function () {
+      var error = this.error
+      var options = this.options
+      return lib.setup(options).catch(function (err) {
+        expect(err).to.eql(error)
+      })
+    })
+
+    context('When ', function () {
+      it('kills the selenium process', function () {
+        var client = this.client
+        var options = this.options
+        options.custom = options.custom || {}
+        options.custom.remoteSelenium = options.custom.remoteSelenium || false
+
+        return lib.setup(options)
+          .catch(function () {})
+          .then(function () {
+            if (options.custom.remoteSelenium) {
+              expect(childProcess.kill).to.not.have.been.called
+            } else {
+              expect(childProcess.kill).to.have.been.calledOnce
+              expect(childProcess.kill).to.have.been.calledAfter(client.end)
+            }
+          })
+      })
+    })
+  })
+
+  context('and WebdriverIO succeeds', function () {
+    it('calls WebdriverIO remote', function () {
+      var opts = {
+        webdriverio: {
+          remote: { desiredCapabilities: { browserName: 'chrome' } }
+        }
+      }
+
+      var options = assign({}, this.options, opts)
+
+      return lib.setup(options).then(function () {
+        expect(webdriverio.remote).to.have.been.calledOnce
+        expect(webdriverio.remote)
+          .to.have.been.calledWithMatch(options.webdriverio.remote)
+      })
+    })
+
+    it('calls WebdriverIO init', function () {
+      var opts = {
+        webdriverio: {
+          init: { desiredCapabilities: { browserName: 'chrome' } }
+        }
+      }
+
+      var options = assign({}, this.options, opts)
+      var initStub = this.initStub
+
+      return lib.setup(options).then(function () {
+        expect(initStub).to.have.been.calledOnce
+        expect(initStub).to.have.been.calledAfter(webdriverio.remote)
+        expect(initStub).to.have.been.calledWithMatch(options.webdriverio.init)
+      })
+    })
+
+    it('returns WebdriverIO client and Selenium process', function () {
+      var client = Promise.resolve()
+      var options = this.options
+      this.initStub.returns(client)
+      return lib.setup(options).then(function (value) {
+        expect(value.browser).to.eql(client)
+        expect((typeof value.selenium.kill)).to.equal('function')
+      })
+    })
+  })
+}

--- a/test/suite.js
+++ b/test/suite.js
@@ -5,22 +5,26 @@ var helper = require('./helpers')
 var seleniumHelper = require('../lib/helpers/selenium')
 var expect = helper.expect
 var sinon = helper.sinon
-
 var lib = require('../lib')
-
 
 var browser = { end: function () {} }
 var childProcess = { kill: function () {} }
+var childPromise = Promise.resolve(childProcess)
+
+var sharedWebdriverIO = require('./shared/webdriverio')
 
 describe('WebdriverIO Test Harness', function () {
   describe('#setup', function () {
     beforeEach(function () {
       this.sandbox = sinon.sandbox.create()
+      this.initStub = this.sandbox.stub()
+
       this.sandbox.stub(webdriverio, 'remote')
       this.sandbox.stub(seleniumHelper, 'setup')
-      this.initStub = this.sandbox.stub()
+      this.sandbox.stub(childProcess, 'kill')
+
       this.initStub.returns(Promise.resolve())
-      seleniumHelper.setup.returns(Promise.resolve())
+      seleniumHelper.setup.returns(childPromise)
       webdriverio.remote.returns({ init: this.initStub })
     })
 
@@ -29,8 +33,12 @@ describe('WebdriverIO Test Harness', function () {
     })
 
     context('With Selenium options', function () {
+      beforeEach(function () {
+        this.options = { selenium: { seleniumArgs: [] } }
+      })
+
       it('setups Selenium', function () {
-        var options = { selenium: { seleniumArgs: [] } }
+        var options = this.options
         return lib.setup(options).then(function () {
           expect(seleniumHelper.setup).to.be.calledOnce
           expect(seleniumHelper.setup).to.be.calledWithMatch(options.selenium)
@@ -47,84 +55,49 @@ describe('WebdriverIO Test Harness', function () {
       })
     })
 
-    context('When Selenium succeeds', function () {
-      context('and with Webdriver options', function () {
-        context('and Webdriverio fails', function () {
-          beforeEach(function () {
-            this.error = { error: true }
-            this.client = Promise.reject(this.error)
-            this.initStub.returns(this.client)
-            this.sandbox.stub(childProcess, 'kill')
-            this.client.end = this.sandbox.stub().returns(Promise.resolve())
-            seleniumHelper.setup.returns(Promise.resolve(childProcess))
-          })
+    context('With Custom Options', function () {
+      context('and remoteSelenium is true', function () {
+        beforeEach(function () {
+          this.options = { custom: { remoteSelenium: true } }
+        })
 
-          it('closes the browser client', function () {
-            var client = this.client
-            return lib.setup({}).catch(function () {
-              expect(client.end).to.have.been.called
-            })
-          })
-
-          it('kills the selenium process', function () {
-            var client = this.client
-            return lib.setup({}).catch(function () {
-              expect(childProcess.kill).to.have.been.calledOnce
-              expect(childProcess.kill).to.have.been.calledAfter(client.end)
-            })
-          })
-
-          it('propagates errors', function () {
-            var error = this.error
-            return lib.setup({}).catch(function (err) {
-              expect(err).to.eql(error)
-            })
+        it('does not start selenium', function () {
+          var options = this.options
+          return lib.setup(options).then(function () {
+            expect(seleniumHelper.setup).to.not.be.called
           })
         })
 
-        context('and Webdriverio succeeds', function () {
-          it('calls WebdriverIO remote', function () {
-            var options = {
-              webdriverio: {
-                remote: { desiredCapabilities: { browserName: 'chrome' } }
-              }
-            }
+        sharedWebdriverIO({
+          lib: lib,
+          seleniumHelper: seleniumHelper,
+          childProcess: childProcess
+        })
+      })
 
-            return lib.setup(options).then(function () {
-              expect(webdriverio.remote).to.have.been.calledOnce
-              expect(webdriverio.remote)
-                .to.have.been.calledWithMatch(options.webdriverio.remote)
-            })
+      context('and remoteSelenium is false', function () {
+        it('setups Selenium', function () {
+          var options = this.options
+          return lib.setup(options).then(function () {
+            expect(seleniumHelper.setup).to.be.calledOnce
+            expect(seleniumHelper.setup).to.be.calledWithMatch({})
           })
+        })
 
-          it('calls WebdriverIO init', function () {
-            var options = {
-              webdriverio: {
-                init: { desiredCapabilities: { browserName: 'chrome' } }
-              }
-            }
-            var initStub = this.initStub
+        sharedWebdriverIO({
+          lib: lib,
+          seleniumHelper: seleniumHelper,
+          childProcess: childProcess
+        })
+      })
+    })
 
-            return lib.setup(options).then(function () {
-              expect(initStub).to.have.been.calledOnce
-              expect(initStub).to.have.been.calledAfter(webdriverio.remote)
-              expect(initStub).to.have.been.calledWithMatch(options.webdriverio.init)
-            })
-          })
-
-          it('returns WebdriverIO client and Selenium process', function () {
-            var client = Promise.resolve(client)
-            var childProcess = { kill: true }
-            this.initStub.returns(client)
-            seleniumHelper.setup.returns(Promise.resolve(childProcess))
-
-            return lib.setup({}).then(function (value) {
-              expect(value).to.eql({
-                browser: client,
-                selenium: childProcess
-              })
-            })
-          })
+    context('When Selenium succeeds', function () {
+      context('and with Webdriver options', function () {
+        sharedWebdriverIO({
+          lib: lib,
+          seleniumHelper: seleniumHelper,
+          childProcess: childProcess
         })
       })
 
@@ -143,6 +116,12 @@ describe('WebdriverIO Test Harness', function () {
             expect(initStub).to.have.been.calledAfter(webdriverio.remote)
             expect(initStub).to.have.been.calledWithMatch({})
           })
+        })
+
+        sharedWebdriverIO({
+          lib: lib,
+          seleniumHelper: seleniumHelper,
+          childProcess: childProcess
         })
       })
     })
@@ -168,9 +147,11 @@ describe('WebdriverIO Test Harness', function () {
     context('Given a Webdriverio client and Selenium process', function () {
       beforeEach(function () {
         this.sandbox = sinon.sandbox.create()
+
         this.sandbox.stub(browser, 'end')
         this.sandbox.stub(childProcess, 'kill')
         this.sandbox.stub(seleniumHelper, 'teardown')
+
         seleniumHelper.teardown.returns(Promise.resolve())
         browser.end.returns(Promise.resolve())
       })


### PR DESCRIPTION
This feature should allow users to turn off the automatic startup of selenium through the test harness.
This is useful for CI servers that will timeout since the instances are a bit wimpy on free accounts.

fixes #8 closes #2  
